### PR TITLE
Fix image link on welcome page

### DIFF
--- a/welcome/README.md
+++ b/welcome/README.md
@@ -23,7 +23,7 @@ For a complete comparison of 8 iOS apps: Fedi, Mast, Mastodon (official), Mercur
 
 This diagram has been making rounds on Twitter, Mastodon, et al. It is from a GitHub issue on the Mastodon project:
 
-<img src="assets/mastodon-toot-visibility-flowchart.jpg" alt="Flow chart showing that a public toot by USER is visible only if you are: following that user, the user is on the same instance as you, or someone on your instanced follows and interacted with the toot" width="200"/>
+<img src="../assets/mastodon-toot-visibility-flowchart.jpg" alt="Flow chart showing that a public toot by USER is visible only if you are: following that user, the user is on the same instance as you, or someone on your instanced follows and interacted with the toot" width="200"/>
 
 This is the case of _public_ toots only. When you are a private account, the people you allow to follow you are the people who can see your toots.
 


### PR DESCRIPTION
Saw a comment that this was broken and happened to be reading the docs so thought I'd help out.

[Rendered](https://github.com/hachyderm/community/blob/293320ef09e89272394eb981fce1276a7dcc0682/welcome/README.md) version seems to respect the relative path. Could also do the [raw URL](https://raw.githubusercontent.com/hachyderm/community/main/assets/mastodon-toot-visibility-flowchart.jpg) to serve it from a CDN, but that would always link to the main branch version.