### PR TITLE
Markdown linting and grammar fixes to #71

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,4 @@
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md025---multiple-top-level-headings-in-the-same-document
+"MD025": false
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md036---emphasis-used-instead-of-a-heading
+"MD036": false

--- a/verification.md
+++ b/verification.md
@@ -65,9 +65,9 @@ the regular verification instructions above.
 
 **First Option: Profile Bio Field**
 
-Note that this method will not work if your Hachyderm username matches
-your, or anyone's, Github username, beause Github will turn the username
-into a link, breaking the verification process.
+Note: This method will not work if your Hachyderm username matches your, or
+anyone's, GitHub username, because GitHub will turn the username into a link,
+breaking the verification process.
 
 1. Add your full Hachyderm / Mastodon username to your GitHub bio.
    * Note: your full username includes the server, e.g. `@username@hachyderm.io`

--- a/verification.md
+++ b/verification.md
@@ -25,14 +25,14 @@ usual, more on that in a moment.)
 In general, when you verify you will do so by using the following HTML on the
 page you are editing, like a personal site or blog:
 
-```
+```html
 <a rel="me" href="https://hachyderm.io/@username">Hachyderm</a>
 ```
 
 If you would like to avoid using a visible link, like the above, you can
 also put the following in the page headers:
 
-```
+```html
 <link rel="me" href="https://hachyderm.io/@username">
 ```
 


### PR DESCRIPTION
Add `.markdownlint.yaml` and ignore `MD025` and `MD036` (since it seems that we're okay with these). Fix the spelling of "GitHub" (it's a compound word) and use the leading "Note:" style, tidies up #71.