### PR TITLE
Attempt to fix build+deploy on merge to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Deploy Hugo site to Pages
 
 on:
+  pull_request:
+    types:
+      - closed
   push:
     branches: [$default-branch]
   workflow_dispatch:
@@ -17,6 +20,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true || github.event_name == "push" || github.event_name == "workflow_dispatch"
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-when-a-pull-request-merges

Desired outcome - the following will trigger build and deploy:
- PRs closed and merged to default brain (`main`)
- Pushes directly to default branch (`main`)
- Manual triggers of the action via GitHub UI**

** - note - I'm not 100% sure of the `event_name = 'workflow_dispatch'` piece. I wasn't able to find documentation, but it seems logical based on other examples!