### PR TITLE
Fix build + deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true || github.event_name == "push" || github.event_name == "workflow_dispatch"
+    if: github.event.pull_request.merged == true || contains(fromJson('["push", "workflow_dispatch"]'), github.event_name)
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true || contains(fromJson('["push", "workflow_dispatch"]'), github.event_name)
+    if: ${{ github.event.pull_request.merged == true || contains(fromJson('["push", "workflow_dispatch"]'), github.event_name) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Following up to #159 - Maybe things will be happier with this syntax?

I am unclear why it did not like that syntax. My read of the docs indicates that should have worked:
https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions

Some searches of other GitHub actions files reveal that it might be wise to use `${{ }}` for `if` statements:
https://github.com/gabriel-miranda/next.js/blob/f8fb6c7a57fb209dc2f0438110cd8a723cb157d1/.github/workflows/build_native.yml#L55

I've also swapped out the event_name match for a `contains` function, so filtering other event types are more straightforward if adding other event types is desired.