### PR TITLE
Give deploy job permission to deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Docs:
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

Example usage for page deploy:
https://stackoverflow.com/questions/72504998/github-actions-unable-to-get-actions-id-token-request-url-env-variable