### PR TITLE
fix(config.toml): fix broken links on the right sidebar

### DIFF
--- a/community.hachyderm.io/config.toml
+++ b/community.hachyderm.io/config.toml
@@ -113,7 +113,7 @@ github_repo = "https://github.com/hachyderm/community"
 github_project_repo = "https://github.com/hachyderm/community"
 
 # Specify a value here if your content directory is not in your repo's root directory
-# github_subdir = ""
+github_subdir = "community.hachyderm.io"
 
 # Uncomment this if your GitHub repo does not have "main" as the default branch,
 # or specify a new value if you want to reference another branch in your GitHub links


### PR DESCRIPTION
Currently, it looks like the links to GitHub are not correct. This is because Hugo supposes that the documentation directory exists on the root directory of the GitHub repository.

![Screenshot 2022-12-05 at 19 50 27](https://user-images.githubusercontent.com/1425259/205619432-a5a0cf50-4f76-4e9f-ab19-4c8af19ac46e.png)

This PR adjusts this path mismatch by adding the `github_subdir` config in `config.toml`.

ref. [Repository Links | Docsy](https://www.docsy.dev/docs/adding-content/repository-links/#github_subdir-optional)

