### PR TITLE
Change `baseURL` value in config to fix RSS feed links

### DIFF
--- a/community.hachyderm.io/config.toml
+++ b/community.hachyderm.io/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://community.hachyderm.io/"
 title = "Hachyderm Community"
 
 # Language settings


### PR DESCRIPTION
Hi! Leaving `baseURL` set to `/` works for links on the community site, but links in RSS feeds are broken and the feeds themselves do not validate.

Setting `baseURL` to `https://community.hachyderm.io/` makes the links absolute at build and, from my testing, does not affect URLs in dev mode.