### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store


### PR DESCRIPTION
This just adds `.DS_Store` to the `.gitignore` so macs don't pollute directories with `.DS_Store` files