### PR TITLE
Update _index.md

### DIFF
--- a/community.hachyderm.io/content/en/docs/account-types/general-accounts/_index.md
+++ b/community.hachyderm.io/content/en/docs/account-types/general-accounts/_index.md
@@ -6,7 +6,7 @@ weight: 20
 
 For the vast majority of Hachyderm users:
 
-Follow our [rules](https://hachyderm.io/about/more#rules) and have fun.
+Follow our [rules](https://community.hachyderm.io/docs/rule-explainer/#the-rule-explainer) and have fun.
 
 Other than our policy, your account, your rules.
 


### PR DESCRIPTION
the link https://hachyderm.io/about#rules no longer has the proper anchors?  Figured it'd make more sense to just link to the rules here in the docs while you're in the docs. 

Though, linking to rules explainer might sound a little confusing.