### PR TITLE
Make uniform links to the Nivenly CLA

### DIFF
--- a/community.hachyderm.io/CONTRIBUTING.md
+++ b/community.hachyderm.io/CONTRIBUTING.md
@@ -5,11 +5,12 @@ just a few small guidelines you need to follow.
 
 ## Contributor License Agreement
 
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution;
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
+Contributions to this project must be accompanied by [a Contributor License
+Agreement](https://cla.nivenly.org/). You (or your employer) retain the
+copyright to your contribution; this simply gives us permission to use and
+redistribute your contributions as part of the project. Head over to
+<https://cla.developers.google.com/> to see your current agreements on file or
+to sign a new one.
 
 You generally only need to submit a CLA once, so if you've already submitted one
 (even if it was for a different project), you probably don't need to do it

--- a/community.hachyderm.io/README.md
+++ b/community.hachyderm.io/README.md
@@ -8,8 +8,8 @@ Here is the static website that is hosted at [community.hachyderm.io](https://co
   parent directory of this repository.
 - We updated the site theme from Docsy v0.5.1 to v0.6.0 on **19 Jan 2023**. If you have
   pending edits from before that time please make sure they work with the theme update.
-- In order to submit PRs / make changes to this repo, you must sign the Nivenly Foundation Contributor License Agreement:<br />
-  https://cla.nivenly.org/
+- In order to submit PRs / make changes to this repo, you must sign [the Nivenly Foundation Contributor License Agreement](https://cla.nivenly.org/).
+
 
 For the Contributor License Agreement:
 * The Nivenly Foundation is the non-profit we're spinning up to house Hachyderm, Aurae, and other OSS Projects.


### PR DESCRIPTION
Because contributor PRs will be blocked absent a signed CLA, this patch aims to make links to the Nivenly CLA harder to miss in the README and CONTRIBUTING guidelines, while also presenting them uniformly.