### PR TITLE
fix: link to rules section

### DIFF
--- a/community.hachyderm.io/content/en/docs/hachyderm/_index.md
+++ b/community.hachyderm.io/content/en/docs/hachyderm/_index.md
@@ -41,7 +41,7 @@ itself dives into those with more nuance, thus the doc page itself is quite long
 reading and understanding just the asks when you're getting started, then coming back once you're
 in a place to dive into the deeper explainations.
 
-Beyond that, you will need to understand [our server rules](/docs/server-rules/)
+Beyond that, you will need to understand [our server rules](/docs/rule-explainer/)
 and [permitted account types](/docs/account-types/) (if you're looking to create a non-general
 user account). The Rule Explainer doc, like the Accessible Posting doc, has the short
 list of rules at the top and then delves into them. Similar to Accessible Posting, we recommend


### PR DESCRIPTION
In welcome section, link to server's rules is redirecting to a non existent section, so now I'm redirecting to rule explainer.

Right now the user faces this error:
![image](https://github.com/hachyderm/community/assets/5982809/db7f6ec2-9e51-404f-8620-744f727327d1)
After the changes the user will be redirected to:
![image](https://github.com/hachyderm/community/assets/5982809/fdfd2b7f-cefe-4aac-9bca-1b8cf3a2e3df)
 
