### PR TITLE
Redis security incident: boot mention of third-party

### DIFF
--- a/community.hachyderm.io/content/en/blog/incidents/2023-07-16-security-redis-cache-exposed/index.md
+++ b/community.hachyderm.io/content/en/blog/incidents/2023-07-16-security-redis-cache-exposed/index.md
@@ -10,9 +10,11 @@ author: Esk ([@esk](https://hachyderm.io/@esk)), Sofi ([@soupglasses](https://ha
 
 Between July 9 and July 16, 2023, one of Hachyderm’s Redis cache servers was exposed to the public internet. On July 16, 2023, the Hachyderm Infrastructure team identified a misconfiguration of our firewall on the cache server which allowed access to the redis interface from the public Internet. After a routine system update, the nftables firewall service was not brought up automatically after a restart, which exposed the Redis cache to the internet for a period of seven days.
 
+During the exposure, an unknown third party attempted to reconfigure our Redis server to act as a replica for a Redis server they controlled. Lucikly, the reconfiguration contained an error which triggered a protective read-only mode in the Hachyderm Redis.
+
 Normally, Hachyderm servers run nftables to block all except necessary traffic from the Internet. We leverage Tailscale for server-to-server communication and only expose ports to the Internet as needed to run Mastodon and administer the systems.
 
-As of July 16, 2023 11:17 UTC, the Hachyderm team has corrected the configuration on our systems and blocked external actors from accessing this Redis instance.
+As of July 16, 2023 11:17 UTC, the Hachyderm team has corrected the configuration on our systems and blocked external actors from accessing this Redis instance. While we do not have any direct evidence the information in the cache was deliberately exfiltrated, because this was exposed to the public internet, we assume the data was compromised.
 
 ## Impact
 


### PR DESCRIPTION
Bump up the mention of the third party reconfig to the Background as not to bury the lede.