### PR TITLE
Pin hugo version to 0.139.4 for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: "latest"
+          hugo-version: "0.139.4"
           extended: true
       - name: Build
         run: make -C community.hachyderm.io hugo


### PR DESCRIPTION
The "latest" hugo version (not guaranteed to build the site) was incremented from 0.139.4 to 0.139.5, however, 0.139.5 appears to result in a 404 when installing hugo. This pins the hugo version to the last known working hugo version.